### PR TITLE
Swap get-BinRoot for Get-ToolsLocation

### DIFF
--- a/ChocolateyPackageUpdater/tools/chocolateyInstall.ps1
+++ b/ChocolateyPackageUpdater/tools/chocolateyInstall.ps1
@@ -2,7 +2,7 @@
 $installDir = Join-Path $toolsDir 'chocopkgup' 
 $installDirBackup = $installDir.Replace("\lib\","\lib-bkp\")
 
-$binRoot = Get-BinRoot
+$binRoot = Get-ToolsLocation
 $oldInstallDir = Join-Path $binRoot 'ChocolateyPackageUpdater'
 $oldInstallDirBackup = Join-Path $binRoot 'ChocolateyPackageUpdater.backup'
 


### PR DESCRIPTION
Swap From Deprecated Get-BinRoot Command over to Get-ToolsLocation

https://github.com/dtgm/chocolatey-packages/issues/179
https://gist.github.com/choco-bot/35a67e1a41a194b624a21a78e8ae27d8

I am new to Chocolatey and need to use this tool to update an outdated automatic package unless there is a new tool that I'm not aware of, the documentation seems to still point to this tool.

I'm still new to this process.